### PR TITLE
fix: delete "localize" that is no longer unnecessary

### DIFF
--- a/footprint/cli.py
+++ b/footprint/cli.py
@@ -64,8 +64,6 @@ def date_parser(date_str, timezone):
     else:
         date_result = today
 
-    date_result = timezone.localize(date_result)
-
     return date_result
 
 

--- a/footprint/modules/github.py
+++ b/footprint/modules/github.py
@@ -28,8 +28,8 @@ class footprintGithub(Github):
         message_info = {}
         for event in self.github_user.get_events():
 
-            from_delta = from_ - timezone.localize(event.created_at)
-            to_delta = to_ - timezone.localize(event.created_at)
+            from_delta = from_ - event.created_at
+            to_delta = to_ - event.created_at
 
             if from_delta.days <= 0 and to_delta.days >= 0:
                 if needs_private or event.raw_data['public']:


### PR DESCRIPTION
fix below.

```
% foot --private
c:\users\laughk\ghq\github.com\laughk\footprint\footprint\cli.py:67: PytzUsageWarning: The localize method is no longer necessary, as this time zone supports the fold attribute (PEP 495). For more details on migrating to a PEP 495-compliant implementation, see https://pytz-deprecation-shim.readthedocs.io/en/latest/migration.html
  date_result = timezone.localize(date_result)
Activity in 2021-12-18
====

c:\users\laughk\ghq\github.com\laughk\footprint\footprint\modules\github.py:31: PytzUsageWarning: The localize method is no longer necessary, as this time zone supports the fold attribute (PEP 495). For more details on migrating to a PEP 495-compliant implementation, see https://pytz-deprecation-shim.readthedocs.io/en/latest/migration.html
  from_delta = from_ - timezone.localize(event.created_at)
c:\users\laughk\ghq\github.com\laughk\footprint\footprint\modules\github.py:32: PytzUsageWarning: The localize method is no longer necessary, as this time zone supports the fold attribute (PEP 495). For more details on migrating to a PEP 495-compliant implementation, see https://pytz-deprecation-shim.readthedocs.io/en/latest/migration.html
  to_delta = to_ - timezone.localize(event.created_at)
```